### PR TITLE
Bump flutter_map dependency to 1.0.0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,7 +75,7 @@ packages:
       name: flutter_map
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "1.0.0"
   flutter_map_marker_popup:
     dependency: "direct main"
     description:
@@ -165,6 +165,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  polylabel:
+    dependency: transitive
+    description:
+      name: polylabel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   positioned_tap_detector_2:
     dependency: transitive
     description:
@@ -233,13 +240,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
-  transparent_image:
-    dependency: transitive
-    description:
-      name: transparent_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   tuple:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   latlong2: ^0.8.0
-  flutter_map: ">=0.14.0 <1.0.0"
+  flutter_map: ^1.0.0
   flutter_map_marker_popup:
     path: ../
 

--- a/lib/src/layout/snap_to_map_layout.dart
+++ b/lib/src/layout/snap_to_map_layout.dart
@@ -44,7 +44,10 @@ abstract class SnapToMapLayout {
   }
 
   static CustomPoint<num> _sizeChangeDueToRotation(MapState mapState) {
-    return mapState.size - (mapState.originalSize ?? mapState.size);
+    // Ugly cast needed because mapState.originalSize is just a CustomPoint?
+    // instead of a CustomPoint<double>? and the type system gets confused.
+    return mapState.size -
+        ((mapState.originalSize ?? mapState.size) as CustomPoint<double>);
   }
 
   static PopupLayout _layoutWith({

--- a/lib/src/layout/snap_to_map_layout.dart
+++ b/lib/src/layout/snap_to_map_layout.dart
@@ -44,10 +44,8 @@ abstract class SnapToMapLayout {
   }
 
   static CustomPoint<num> _sizeChangeDueToRotation(MapState mapState) {
-    // Ugly cast needed because mapState.originalSize is just a CustomPoint?
-    // instead of a CustomPoint<double>? and the type system gets confused.
-    return mapState.size -
-        ((mapState.originalSize ?? mapState.size) as CustomPoint<double>);
+    final CustomPoint<num> size = mapState.size;
+    return size - (mapState.originalSize ?? mapState.size);
   }
 
   static PopupLayout _layoutWith({

--- a/lib/src/marker_layer.dart
+++ b/lib/src/marker_layer.dart
@@ -12,9 +12,7 @@ class MarkerLayer extends StatefulWidget {
 
   final MapState map;
 
-  // Forced to use this type by flutter_map
-  // ignore: prefer_void_to_null
-  final Stream<Null>? stream;
+  final Stream<void>? stream;
 
   final PopupControllerImpl popupController;
 
@@ -70,9 +68,9 @@ class _MarkerLayerState extends State<MarkerLayer>
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<int?>(
-      stream: widget.stream, // a Stream<int> or null
-      builder: (BuildContext context, AsyncSnapshot<int?> snapshot) {
+    return StreamBuilder<void>(
+      stream: widget.stream,
+      builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
         var markers = <Widget>[];
         final sameZoom = widget.map.zoom == lastZoom;
         for (var i = 0; i < widget.layerOptions.markers.length; i++) {

--- a/lib/src/popup_layer.dart
+++ b/lib/src/popup_layer.dart
@@ -10,10 +10,7 @@ import 'popup_event.dart';
 
 class PopupLayer extends StatefulWidget {
   final MapState mapState;
-
-  // Forced by flutter_map
-  // ignore: prefer_void_to_null
-  final Stream<Null>? stream;
+  final Stream<void>? stream;
   final PopupBuilder popupBuilder;
   final PopupSnap popupSnap;
   final PopupControllerImpl popupController;
@@ -65,9 +62,9 @@ class _PopupLayerState extends State<PopupLayer> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<int?>(
-      stream: widget.stream, // a Stream<int> or null
-      builder: (BuildContext context, AsyncSnapshot<int?> snapshot) {
+    return StreamBuilder<void>(
+      stream: widget.stream,
+      builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
         final popupAnimation = widget.popupAnimation;
 
         if (popupAnimation == null) {

--- a/lib/src/popup_marker_layer_options.dart
+++ b/lib/src/popup_marker_layer_options.dart
@@ -81,9 +81,7 @@ class PopupMarkerLayerOptions extends MarkerLayerOptions {
     PopupController? popupController,
     MarkerTapBehavior? markerTapBehavior,
     this.onPopupEvent,
-    // Forced by flutter_map
-    // ignore: prefer_void_to_null
-    Stream<Null>? rebuild,
+    Stream<void>? rebuild,
   })  : popupController = popupController ?? PopupControllerImpl(),
         markerTapBehavior =
             markerTapBehavior ?? MarkerTapBehavior.togglePopupAndHideRest(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -75,7 +75,7 @@ packages:
       name: flutter_map
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.1"
+    version: "1.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -87,14 +87,14 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.4"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   intl:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       name: latlong2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0"
+    version: "0.8.1"
   lints:
     dependency: transitive
     description:
@@ -122,7 +122,7 @@ packages:
       name: lists
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -136,7 +136,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -157,21 +157,21 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
-  pedantic:
+    version: "1.8.1"
+  polylabel:
     dependency: transitive
     description:
-      name: pedantic
+      name: polylabel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.0.1"
   positioned_tap_detector_2:
     dependency: transitive
     description:
       name: positioned_tap_detector_2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.4"
   proj4dart:
     dependency: transitive
     description:
@@ -185,7 +185,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -197,7 +197,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -232,14 +232,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  transparent_image:
-    dependency: transitive
-    description:
-      name: transparent_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
+    version: "0.4.9"
   tuple:
     dependency: transitive
     description:
@@ -253,21 +246,21 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   unicode:
     dependency: transitive
     description:
       name: unicode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   wkt_parser:
     dependency: transitive
     description:
@@ -276,5 +269,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_map: ">=0.13.1 <1.0.0"
+  flutter_map: ^1.0.0
   latlong2: ">=0.7.0 <1.0.0"
   animated_stack_widget: ^0.0.4
 


### PR DESCRIPTION
Fixes breaking changes introduced since the last major flutter_map
release. Primarily instances of `Stream<Null>` used in the plugin API now
have become `Stream<void>`.

Closes #44 