### PR TITLE
Fix Import conflict for LatLngTween with flutter_map 6.0.1

### DIFF
--- a/lib/src/marker_layer.dart
+++ b/lib/src/marker_layer.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map_marker_popup/src/lat_lng_tween.dart';
 import 'package:flutter_map_marker_popup/src/options/popup_marker_layer_options.dart';
 import 'package:flutter_map_marker_popup/src/popup_spec.dart';
 import 'package:flutter_map_marker_popup/src/state/popup_state.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
 
   animated_stack_widget: ^0.0.4
-  flutter_map: ^6.0.0
+  flutter_map: ^6.0.1
   latlong2: ^0.9.0
   provider: ^6.0.5
 


### PR DESCRIPTION
flutter_map 6.0.1 includes a LatLngTween import which causes a build error as described in https://github.com/rorystephenson/flutter_map_marker_popup/issues/72