### PR TITLE
chore: Upgrade to flutter_map 8.0.0 and Dart 3.6.0

### DIFF
--- a/example/lib/full_example.dart
+++ b/example/lib/full_example.dart
@@ -50,8 +50,7 @@ class _FullExampleState extends State<FullExample> {
     super.didUpdateWidget(oldWidget);
 
     final selectedMarkers = widget.popupState.selectedMarkers;
-    if (widget.markerAlignment != oldWidget.markerAlignment ||
-        widget.rotate != oldWidget.rotate) {
+    if (widget.markerAlignment != oldWidget.markerAlignment || widget.rotate != oldWidget.rotate) {
       setState(() {
         _markers = _buildMarkers();
       });
@@ -61,8 +60,7 @@ class _FullExampleState extends State<FullExample> {
       /// anchor point change). If we can match one of the new Markers to the
       /// old Marker that had the popup then we can show the popup for that
       /// Marker.
-      final matchingMarkers = _markers.where((marker) => selectedMarkers
-          .any((selectedMarker) => marker.point == selectedMarker.point));
+      final matchingMarkers = _markers.where((marker) => selectedMarkers.any((selectedMarker) => marker.point == selectedMarker.point));
 
       if (matchingMarkers.isNotEmpty) {
         debugPrint('We here');
@@ -79,8 +77,7 @@ class _FullExampleState extends State<FullExample> {
     /// If we change to show only one popup at a time we should hide all popups
     /// apart from the first one.
     if (!widget.showMultiplePopups && oldWidget.showMultiplePopups) {
-      final matchingMarkers = _markers.where((marker) => selectedMarkers
-          .any((selectedMarker) => marker.point == selectedMarker.point));
+      final matchingMarkers = _markers.where((marker) => selectedMarkers.any((selectedMarker) => marker.point == selectedMarker.point));
 
       if (matchingMarkers.length > 1) {
         _popupController.showPopupsOnlyFor([matchingMarkers.first]);
@@ -125,7 +122,7 @@ class _FullExampleState extends State<FullExample> {
         rotate: widget.rotate,
         child: Container(
           decoration: BoxDecoration(
-            color: Colors.blue.withOpacity(0.5),
+            color: Colors.blue.withValues(alpha: 0.5),
             border: Border.all(color: Colors.black, width: 0.0),
             borderRadius: const BorderRadius.all(Radius.elliptical(40, 20)),
           ),
@@ -157,17 +154,11 @@ class _FullExampleState extends State<FullExample> {
               popupDisplayOptions: !widget.showPopups
                   ? null
                   : PopupDisplayOptions(
-                      builder: (BuildContext context, Marker marker) =>
-                          ExamplePopup(marker),
+                      builder: (BuildContext context, Marker marker) => ExamplePopup(marker),
                       snap: widget.snap,
-                      animation: widget.fade
-                          ? const PopupAnimation.fade(
-                              duration: Duration(milliseconds: 700))
-                          : null,
+                      animation: widget.fade ? const PopupAnimation.fade(duration: Duration(milliseconds: 700)) : null,
                     ),
-              markerTapBehavior: widget.showMultiplePopups
-                  ? MarkerTapBehavior.togglePopup()
-                  : MarkerTapBehavior.togglePopupAndHideRest(),
+              markerTapBehavior: widget.showMultiplePopups ? MarkerTapBehavior.togglePopup() : MarkerTapBehavior.togglePopupAndHideRest(),
               onPopupEvent: (event, selectedMarkers) {
                 ScaffoldMessenger.of(context).hideCurrentSnackBar();
                 ScaffoldMessenger.of(context).showSnackBar(

--- a/example/lib/widget_between_popups_and_markers_page.dart
+++ b/example/lib/widget_between_popups_and_markers_page.dart
@@ -12,12 +12,10 @@ class WidgetBetweenPopupsAndMarkersPage extends StatefulWidget {
   const WidgetBetweenPopupsAndMarkersPage({super.key});
 
   @override
-  State<WidgetBetweenPopupsAndMarkersPage> createState() =>
-      _WidgetBetweenPopupsAndMarkersPageState();
+  State<WidgetBetweenPopupsAndMarkersPage> createState() => _WidgetBetweenPopupsAndMarkersPageState();
 }
 
-class _WidgetBetweenPopupsAndMarkersPageState
-    extends State<WidgetBetweenPopupsAndMarkersPage> {
+class _WidgetBetweenPopupsAndMarkersPageState extends State<WidgetBetweenPopupsAndMarkersPage> {
   late final List<Marker> _markersA;
   late final List<Marker> _markersB;
 
@@ -74,13 +72,11 @@ class _WidgetBetweenPopupsAndMarkersPageState
                 options: MapOptions(
                   initialZoom: 5.0,
                   initialCenter: const LatLng(44.421, 10.404),
-                  onTap: (_, __) => _popupLayerController
-                      .hideAllPopups(), // Hide popup when the map is tapped.
+                  onTap: (_, __) => _popupLayerController.hideAllPopups(), // Hide popup when the map is tapped.
                 ),
                 children: [
                   TileLayer(
-                    urlTemplate:
-                        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   ),
                   PopupMarkerLayer(
                     options: PopupMarkerLayerOptions(
@@ -92,12 +88,10 @@ class _WidgetBetweenPopupsAndMarkersPageState
                       markers: _markersB,
                     ),
                   ),
-                  IgnorePointer(
-                      child: Container(color: Colors.red.withOpacity(0.2))),
+                  IgnorePointer(child: Container(color: Colors.red.withValues(alpha: 0.2))),
                   PopupLayer(
                     popupDisplayOptions: PopupDisplayOptions(
-                      builder: (BuildContext context, Marker marker) =>
-                          ExamplePopup(marker),
+                      builder: (BuildContext context, Marker marker) => ExamplePopup(marker),
                     ),
                   ),
                 ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   characters:
     dependency: transitive
     description:
@@ -29,26 +29,26 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   dart_earcut:
     dependency: transitive
     description:
       name: dart_earcut
-      sha256: "41b493147e30a051efb2da1e3acb7f38fe0db60afba24ac1ea5684cee272721e"
+      sha256: e485001bfc05dcbc437d7bfb666316182e3522d4c3f9668048e004d0eb2ce43b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -58,49 +58,49 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: ad76540d21c066228ee3f9d1dad64a9f7e46530e8bb7c85011a88bc1fd874bc5
+      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   flutter_map:
     dependency: "direct main"
     description:
       name: flutter_map
-      sha256: ead3532d99548140346684cf737a4c0a6f59f02f62ee4e406597f8364afbf1a2
+      sha256: "82786b8e1ffbff079487eeeed59a34e8a0b09896dd7713d8e1dc193d673496b5"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "8.0.0"
   flutter_map_marker_popup:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "7.0.0"
+    version: "8.0.0"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.1.2"
   intl:
     dependency: transitive
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.20.2"
   latlong2:
     dependency: "direct main"
     description:
@@ -129,26 +129,26 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: af05cc8714f356fd1f3888fb6741cbe9fbe25cdb6eedbab80e1a6db21047d4a4
+      sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.5.0"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -169,10 +169,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   polylabel:
     dependency: transitive
     description:
@@ -193,47 +193,47 @@ packages:
     dependency: transitive
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   unicode:
     dependency: transitive
     description:
@@ -254,10 +254,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.0"
   wkt_parser:
     dependency: transitive
     description:
@@ -267,5 +267,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.10.0"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,15 +3,15 @@ description: Example for Flutter Map Marker Popups.
 publish_to: 'none'
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
   latlong2: ^0.9.0
-  flutter_map: ^7.0.0
+  flutter_map: ^8.0.0
   flutter_map_marker_popup:
     path: ../
 

--- a/lib/src/layout/popup_calculations.dart
+++ b/lib/src/layout/popup_calculations.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'dart:ui';
 
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_popup/src/popup_spec.dart';
@@ -58,43 +58,43 @@ abstract class PopupCalculations {
 
   static double mapLeftToPointX(
     MapCamera mapCamera,
-    Point<num> point,
+    Offset point,
   ) {
-    return point.x.toDouble();
+    return point.dx.toDouble();
   }
 
   static double mapRightToPointX(
     MapCamera mapCamera,
-    Point<num> point,
+    Offset point,
   ) {
-    return -(mapCamera.size.x - point.x).toDouble();
+    return -(mapCamera.size.width - point.dx).toDouble();
   }
 
   static double mapCenterToPointX(
     MapCamera mapCamera,
-    Point<num> point,
+    Offset point,
   ) {
-    return -(mapCamera.size.x / 2 - point.x).toDouble();
+    return -(mapCamera.size.width / 2 - point.dx).toDouble();
   }
 
   static double mapTopToPointY(
     MapCamera mapCamera,
-    Point<num> point,
+    Offset point,
   ) {
-    return point.y.toDouble();
+    return point.dy.toDouble();
   }
 
   static double mapBottomToPointY(
     MapCamera mapCamera,
-    Point<num> point,
+    Offset point,
   ) {
-    return -(mapCamera.size.y - point.y).toDouble();
+    return -(mapCamera.size.height - point.dy).toDouble();
   }
 
   static double mapCenterToPointY(
     MapCamera mapCamera,
-    Point<num> point,
+    Offset point,
   ) {
-    return -(mapCamera.size.y / 2 - point.y).toDouble();
+    return -(mapCamera.size.height / 2 - point.dy).toDouble();
   }
 }

--- a/lib/src/layout/popup_container_translate.dart
+++ b/lib/src/layout/popup_container_translate.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_popup/src/popup_spec.dart';
@@ -40,10 +38,8 @@ abstract class PopupContainerTransform {
     final markerPoint = _markerPoint(mapCamera, popupSpec);
 
     return Matrix4.translationValues(
-      PopupCalculations.mapRightToPointX(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetX(popupSpec),
-      PopupCalculations.mapCenterToPointY(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetY(popupSpec),
+      PopupCalculations.mapRightToPointX(mapCamera, markerPoint) + PopupCalculations.centerOffsetX(popupSpec),
+      PopupCalculations.mapCenterToPointY(mapCamera, markerPoint) + PopupCalculations.centerOffsetY(popupSpec),
       0.0,
     )
       ..rotateZ(-mapCamera.rotationRad)
@@ -77,10 +73,8 @@ abstract class PopupContainerTransform {
     final markerPoint = _markerPoint(mapCamera, popupSpec);
 
     return Matrix4.translationValues(
-      PopupCalculations.mapCenterToPointX(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetX(popupSpec),
-      PopupCalculations.mapBottomToPointY(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetY(popupSpec),
+      PopupCalculations.mapCenterToPointX(mapCamera, markerPoint) + PopupCalculations.centerOffsetX(popupSpec),
+      PopupCalculations.mapBottomToPointY(mapCamera, markerPoint) + PopupCalculations.centerOffsetY(popupSpec),
       0.0,
     )
       ..rotateZ(-mapCamera.rotationRad)
@@ -115,10 +109,8 @@ abstract class PopupContainerTransform {
     final markerPoint = _markerPoint(mapCamera, popupSpec);
 
     return Matrix4.translationValues(
-      PopupCalculations.mapLeftToPointX(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetX(popupSpec),
-      PopupCalculations.mapCenterToPointY(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetY(popupSpec),
+      PopupCalculations.mapLeftToPointX(mapCamera, markerPoint) + PopupCalculations.centerOffsetX(popupSpec),
+      PopupCalculations.mapCenterToPointY(mapCamera, markerPoint) + PopupCalculations.centerOffsetY(popupSpec),
       0.0,
     )
       ..rotateZ(-mapCamera.rotationRad)
@@ -152,10 +144,8 @@ abstract class PopupContainerTransform {
     final markerPoint = _markerPoint(mapCamera, popupSpec);
 
     return Matrix4.translationValues(
-      PopupCalculations.mapCenterToPointX(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetX(popupSpec),
-      PopupCalculations.mapTopToPointY(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetY(popupSpec),
+      PopupCalculations.mapCenterToPointX(mapCamera, markerPoint) + PopupCalculations.centerOffsetX(popupSpec),
+      PopupCalculations.mapTopToPointY(mapCamera, markerPoint) + PopupCalculations.centerOffsetY(popupSpec),
       0.0,
     )
       ..rotateZ(-mapCamera.rotationRad)
@@ -190,19 +180,16 @@ abstract class PopupContainerTransform {
     final markerPoint = _markerPoint(mapCamera, popupSpec);
 
     return Matrix4.translationValues(
-      PopupCalculations.mapCenterToPointX(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetX(popupSpec),
-      PopupCalculations.mapCenterToPointY(mapCamera, markerPoint) +
-          PopupCalculations.centerOffsetY(popupSpec),
+      PopupCalculations.mapCenterToPointX(mapCamera, markerPoint) + PopupCalculations.centerOffsetX(popupSpec),
+      PopupCalculations.mapCenterToPointY(mapCamera, markerPoint) + PopupCalculations.centerOffsetY(popupSpec),
       0.0,
     )..rotateZ(-mapCamera.rotationRad);
   }
 
-  static Point<num> _markerPoint(
+  static Offset _markerPoint(
     MapCamera mapCamera,
     PopupSpec popupSpec,
   ) {
-    return mapCamera.project(popupSpec.markerPoint) -
-        mapCamera.pixelOrigin.toDoublePoint();
+    return mapCamera.projectAtZoom(popupSpec.markerPoint) - mapCamera.pixelOrigin;
   }
 }

--- a/lib/src/layout/snap_to_map_layout.dart
+++ b/lib/src/layout/snap_to_map_layout.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
@@ -10,7 +8,7 @@ abstract class SnapToMapLayout {
     return _layoutWith(
       contentAlignment: Alignment.centerLeft,
       mapRotationRad: mapCamera.rotationRad,
-      translateX: _sizeChangeDueToRotation(mapCamera).x / 2,
+      translateX: _sizeChangeDueToRotation(mapCamera).dx / 2,
     );
   }
 
@@ -18,7 +16,7 @@ abstract class SnapToMapLayout {
     return _layoutWith(
       contentAlignment: Alignment.topCenter,
       mapRotationRad: mapCamera.rotationRad,
-      translateY: _sizeChangeDueToRotation(mapCamera).y / 2,
+      translateY: _sizeChangeDueToRotation(mapCamera).dy / 2,
     );
   }
 
@@ -26,7 +24,7 @@ abstract class SnapToMapLayout {
     return _layoutWith(
       contentAlignment: Alignment.centerRight,
       mapRotationRad: mapCamera.rotationRad,
-      translateX: -_sizeChangeDueToRotation(mapCamera).x / 2,
+      translateX: -_sizeChangeDueToRotation(mapCamera).dx / 2,
     );
   }
 
@@ -34,7 +32,7 @@ abstract class SnapToMapLayout {
     return _layoutWith(
       contentAlignment: Alignment.bottomCenter,
       mapRotationRad: mapCamera.rotationRad,
-      translateY: -_sizeChangeDueToRotation(mapCamera).y / 2,
+      translateY: -_sizeChangeDueToRotation(mapCamera).dy / 2,
     );
   }
 
@@ -45,8 +43,7 @@ abstract class SnapToMapLayout {
     );
   }
 
-  static Point<double> _sizeChangeDueToRotation(MapCamera mapCamera) =>
-      mapCamera.size - mapCamera.nonRotatedSize;
+  static Offset _sizeChangeDueToRotation(MapCamera mapCamera) => (mapCamera.size - mapCamera.nonRotatedSize) as Offset;
 
   static PopupLayout _layoutWith({
     required Alignment contentAlignment,

--- a/lib/src/marker_layer.dart
+++ b/lib/src/marker_layer.dart
@@ -30,8 +30,7 @@ class MarkerLayer extends StatefulWidget {
   State<MarkerLayer> createState() => _MarkerLayerState();
 }
 
-class _MarkerLayerState extends State<MarkerLayer>
-    with SingleTickerProviderStateMixin {
+class _MarkerLayerState extends State<MarkerLayer> with SingleTickerProviderStateMixin {
   late AnimationController _centerMarkerController;
   void Function()? _animationListener;
 
@@ -64,32 +63,28 @@ class _MarkerLayerState extends State<MarkerLayer>
         children: (List<Marker> markers) sync* {
           for (final m in markers) {
             // Resolve real alignment
-            final left =
-                0.5 * m.width * ((m.alignment ?? Alignment.center).x + 1);
-            final top =
-                0.5 * m.height * ((m.alignment ?? Alignment.center).y + 1);
+            final left = 0.5 * m.width * ((m.alignment ?? Alignment.center).x + 1);
+            final top = 0.5 * m.height * ((m.alignment ?? Alignment.center).y + 1);
             final right = m.width - left;
             final bottom = m.height - top;
 
             // Perform projection
-            final pxPoint = map.project(m.point);
+            final pxPoint = map.projectAtZoom(m.point);
 
             // Cull if out of bounds
-            if (!map.pixelBounds.containsPartialBounds(
-              Bounds(
-                Point(pxPoint.x + left, pxPoint.y - bottom),
-                Point(pxPoint.x - right, pxPoint.y + top),
+            if (!map.pixelBounds.overlaps(
+              Rect.fromPoints(
+                Offset(pxPoint.dx + left, pxPoint.dy - bottom),
+                Offset(pxPoint.dx - right, pxPoint.dy + top),
               ),
             )) continue;
 
             // Apply map camera to marker position
-            final pos = Point(pxPoint.x - map.pixelOrigin.x, pxPoint.y - map.pixelOrigin.y);
+            final pos = Point(pxPoint.dx - map.pixelOrigin.dx, pxPoint.dy - map.pixelOrigin.dy);
 
             var markerChild = m.child;
-            if (widget.layerOptions.selectedMarkerBuilder != null &&
-                widget.popupState.isSelected(m)) {
-              markerChild =
-                  widget.layerOptions.selectedMarkerBuilder!(context, m);
+            if (widget.layerOptions.selectedMarkerBuilder != null && widget.popupState.isSelected(m)) {
+              markerChild = widget.layerOptions.selectedMarkerBuilder!(context, m);
             }
             final markerWithGestureDetector = GestureDetector(
               onTap: () {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,18 +45,18 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   dart_earcut:
     dependency: transitive
     description:
       name: dart_earcut
-      sha256: "41b493147e30a051efb2da1e3acb7f38fe0db60afba24ac1ea5684cee272721e"
+      sha256: e485001bfc05dcbc437d7bfb666316182e3522d4c3f9668048e004d0eb2ce43b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   fake_async:
     dependency: transitive
     description:
@@ -82,10 +82,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_map
-      sha256: ead3532d99548140346684cf737a4c0a6f59f02f62ee4e406597f8364afbf1a2
+      sha256: "82786b8e1ffbff079487eeeed59a34e8a0b09896dd7713d8e1dc193d673496b5"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "8.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -95,26 +95,26 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.1.2"
   intl:
     dependency: transitive
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.20.2"
   latlong2:
     dependency: "direct main"
     description:
@@ -127,18 +127,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -167,10 +167,10 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: af05cc8714f356fd1f3888fb6741cbe9fbe25cdb6eedbab80e1a6db21047d4a4
+      sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.5.0"
   matcher:
     dependency: transitive
     description:
@@ -183,18 +183,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -239,15 +239,15 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -260,10 +260,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -276,10 +276,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -292,18 +292,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   unicode:
     dependency: transitive
     description:
@@ -324,18 +324,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.0"
   wkt_parser:
     dependency: transitive
     description:
@@ -345,5 +345,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,21 @@
 name: flutter_map_marker_popup
 description: Marker popups for flutter_map.
-version: 7.0.0
+version: 8.0.0
 homepage: https://github.com/rorystephenson/flutter_map_marker_popup
 topics:
   - flutter-map
   - popups
-
+  
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
   animated_stack_widget: ^0.0.4
-  flutter_map: ^7.0.0
+  flutter_map: ^8.0.0
   latlong2: ^0.9.0
   provider: ^6.0.5
 


### PR DESCRIPTION
Flutter Map version 8 introduces significant internal changes aimed at enhancing performance by reducing type casting. A key modification is the migration from using Point<double> to Offset and from Bounds<double> to Rect. These changes streamline the codebase and improve efficiency.

To align with these updates, this pull request focuses on updating the library to adhere to the new standards set by Flutter Map v8. The primary goal is to refactor the codebase to utilize Offset and Rect where appropriate, replacing the previous usage of Point<double> and Bounds<double>. This transition not only aligns the library with the latest practices but also contributes to improved performance and code clarity.

By adopting these new patterns, we aim to enhance the library's performance and maintainability, ensuring compatibility with Flutter Map v8's optimized architecture.