### PR TITLE
URGENT: MarkerLayer skipped ALL markers

### DIFF
--- a/lib/src/marker_layer.dart
+++ b/lib/src/marker_layer.dart
@@ -76,7 +76,7 @@ class _MarkerLayerState extends State<MarkerLayer>
 
             // Cull if out of bounds
             if (
-              !map.pixelBounds.contains(Offset(pxPoint.dx + left, pxPoint.dy - bottom)) ||
+              !map.pixelBounds.contains(Offset(pxPoint.dx + left, pxPoint.dy - bottom)) &&
               !map.pixelBounds.contains(Offset(pxPoint.dx - right, pxPoint.dy + top))
             ) {
               continue;

--- a/lib/src/marker_layer.dart
+++ b/lib/src/marker_layer.dart
@@ -74,11 +74,11 @@ class _MarkerLayerState extends State<MarkerLayer>
             // Perform projection
             final pxPoint = map.projectAtZoom(m.point);
 
-            final width = (pxPoint.dx + left) - (pxPoint.dx - right);
-            final height = (pxPoint.dy + top) - (pxPoint.dy - bottom);
-
             // Cull if out of bounds
-            if (!map.pixelBounds.contains(Offset(width, height))) {
+            if (
+              !map.pixelBounds.contains(Offset(pxPoint.dx + left, pxPoint.dy - bottom)) ||
+              !map.pixelBounds.contains(Offset(pxPoint.dx - right, pxPoint.dy + top))
+            ) {
               continue;
             }
 


### PR DESCRIPTION
Fixed calculation for skip markers that out of visible bounds.

In [./lib/src/marker_layer.dart:79](https://github.com/rorystephenson/flutter_map_marker_popup/pull/86/files#r2062743455)  Marker always out of bounds (( 

Fixed in this PR